### PR TITLE
#9 オフィスの更新処理実装

### DIFF
--- a/app/Http/Controllers/OfficesController.php
+++ b/app/Http/Controllers/OfficesController.php
@@ -3,12 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\OfficeStoreRequest;
+use App\Http\Requests\OfficeUpdateRequest;
 use App\Models\Office;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 
 class OfficesController extends Controller
@@ -20,7 +20,7 @@ class OfficesController extends Controller
     public function index()
     {
         $offices = Office::all();
-        return view('offices.index', ['offices' => $offices]);
+        return view('offices.index', compact('offices'));
     }
 
     /**
@@ -31,7 +31,7 @@ class OfficesController extends Controller
     public function show(int $id)
     {
         $office = Office::findorFail($id);
-        return view('offices.show', ['office' => $office]);
+        return view('offices.show', compact('office'));
     }
 
     /**
@@ -44,32 +44,59 @@ class OfficesController extends Controller
     }
 
     /**
-     * 物件登録処理(ajax)
-     * @param OfficeStoreRequest $request
-     * @return  JsonResponse
+     * 物件編集
+     * @param int $id
+     * @return Application|Factory|View
      */
-    public function store(OfficeStoreRequest $request)
+    public function edit(int $id)
     {
-        (new Office)->registerOffice(
-            $request->only('name', 'address', 'post_code', 'stair', 'comment')
-        );
-
-        return response()->json(['message' => '登録しました']);
+        $office = Office::findorFail($id);
+        return view('offices.edit', compact('office'));
     }
 
 //    /**
-//     * 物件登録処理
+//     * 物件登録処理(ajax)
 //     * @param OfficeStoreRequest $request
-//     * @return RedirectResponse
+//     * @return  JsonResponse
 //     */
-//    public function store(OfficeStoreRequest $request): RedirectResponse
+//    public function store(OfficeStoreRequest $request)
 //    {
-//
-//        (new office())->registerOffice(
+//        (new Office)->registerOffice(
 //            $request->only('name', 'address', 'post_code', 'stair', 'comment')
 //        );
 //
-//        return redirect()->route('offices.index');
+//        return response()->json(['message' => '登録しました']);
 //    }
+
+    /**
+     * 物件登録処理
+     * @param OfficeStoreRequest $request
+     * @return RedirectResponse
+     */
+    public function store(OfficeStoreRequest $request): RedirectResponse
+    {
+
+        (new office())->registerOffice(
+            $request->only('name', 'address', 'post_code', 'stair', 'comment')
+        );
+
+        return redirect()->route('offices.index');
+    }
+
+    /**
+     * 物件更新処理
+     * @param OfficeUpdateRequest $request
+     * @param int $id
+     * @return RedirectResponse
+     */
+    public function update(OfficeUpdateRequest $request, int $id): RedirectResponse
+    {
+        Office::updateOffice(
+            $id,
+            $request->only('name', 'address', 'post_code', 'stair', 'comment')
+        );
+
+        return redirect()->route('offices.index');
+    }
 
 }

--- a/app/Http/Requests/OfficeUpdateRequest.php
+++ b/app/Http/Requests/OfficeUpdateRequest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Unique;
+
+class OfficeUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string|Unique>>
+     */
+    public function rules(): array
+    {
+        $officeId = $this->route('id');
+
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:50',
+            ],
+            'address' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('offices')->ignore($officeId),
+            ],
+            'post_code' => [
+                'required',
+                'string',
+                'size:7',
+            ],
+            'stair' => [
+                'required',
+                'integer',
+            ],
+            'comment' => [
+                'required',
+                'string',
+                'max:255',
+            ],
+        ];
+    }
+
+    /**
+     * カスタム属性名
+     * @return array<string, string>
+     */
+    public function attributes(): array
+    {
+        return [
+            'name' => '施設名',
+            'address' => '住所',
+            'post_code' => '郵便番号',
+            'stair' => '階数',
+            'comment' => '備考',
+        ];
+    }
+
+    /**
+     * バリデーションエラーメッセージ
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => ':attributeは必須です',
+            'name.string' => ':attributeは文字列を入力してください',
+            'name.max' => ':attributeは:max文字以内で入力してください',
+            'address.required' => ':attributeは必須です',
+            'address.string' => ':attributeは文字列を入力してください',
+            'address.max' => ':attributeは:max文字以内で入力してください',
+            'address.unique' => 'この:attributeは既に登録されています',
+            'post_code.required' => ':attributeは必須です',
+            'post_code.integer' => ':attributeは数字で入力してください',
+            'post_code.size' => ':attributeは:size桁で入力してください',
+            'stair.required' => ':attributeは必須です',
+            'stair.integer' => ':attributeは数字で入力してください',
+            'comment.required' => ':attributeは必須です',
+            'comment.string' => ':attributeは文字列を入力してください',
+            'comment.max' => ':attributeは:max文字以内で入力してください',
+        ];
+    }
+}

--- a/app/Models/Office.php
+++ b/app/Models/Office.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Eloquent;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 /**
  * class Office
@@ -33,5 +34,19 @@ class Office extends Model
     public function registerOffice(array $inputData): void
     {
         (new self)->fill($inputData)->save();
+    }
+
+    /**
+     * オフィスの更新処理
+     * @param int $id
+     * @param array<string, string|int> $inputData
+     * @return void
+     */
+    public static function updateOffice(int $id, array $inputData): void
+    {
+        // 必要ない?
+        DB::transaction(function () use ($id, $inputData) {
+            Office::findorFail($id)->fill($inputData)->save();
+        });
     }
 }

--- a/resources/views/offices/components/form.blade.php
+++ b/resources/views/offices/components/form.blade.php
@@ -1,0 +1,36 @@
+@if ($errors->any())
+    <ul>
+        @foreach ($errors->all() as $error)
+            <li>{{ $error }}</li>
+        @endforeach
+    </ul>
+@endif
+<form action="{{ $action }}" method="post">
+    @csrf
+    @if($isUpdate)
+        @method('PUT')
+    @endif
+    <table>
+        <tr>
+            <td><label for="name">施設名</label></td>
+            <td><input type="text" name="name" id="name" value="{{ old('name', $office->name ?? '') }}"/></td>
+        </tr>
+        <tr>
+            <td><label for="address">住所</label></td>
+            <td><input type="text" name="address" id="address" value="{{ old('address', $office->address ?? '') }}" /></td>
+        </tr>
+        <tr>
+            <td><label for="post_code">郵便番号</label></td>
+            <td><input type="text" name="post_code" id="post_code" value="{{ old('post_code', $office->post_code ?? '') }}" /></td>
+        </tr>
+        <tr>
+            <td><label for="stair">階</label></td>
+            <td><input type="text" name="stair" id="stair" value="{{ old('stair', $office->stair ?? '') }}" /></td>
+        </tr>
+        <tr>
+            <td><label for="comment">コメント</label></td>
+            <td><textarea name="comment" id="comment">{{ old('comment', $office->comment ?? '') }}</textarea></td>
+        </tr>
+    </table>
+    <button type="submit">{{ $isUpdate ? '更新' : '登録' }}</button>
+</form>

--- a/resources/views/offices/create.blade.php
+++ b/resources/views/offices/create.blade.php
@@ -1,71 +1,43 @@
 @extends('layouts.app')
 @section('title', 'create office')
 @push('js')
+    {{-- ajaxで使う --}}
     <script src="{{ mix('js/pages/offices/create.js') }}"></script>
 @endpush
 
 @section('content')
-    <ul data-error-message></ul>
-    <form data-office-create>
-        @csrf
-        <table>
-            <tr>
-                <td><label for="name">施設名</label></td>
-                <td><input type="text" name="name" id="name" value="{{ old('name') }}"/></td>
-            </tr>
-            <tr>
-                <td><label for="address">住所</label></td>
-                <td><input type="text" name="address" id="address" value="{{ old('address') }}" /></td>
-            </tr>
-            <tr>
-                <td><label for="post_code">郵便番号</label></td>
-                <td><input type="text" name="post_code" id="post_code" value="{{ old('post_code') }}" /></td>
-            </tr>
-            <tr>
-                <td><label for="stair">階</label></td>
-                <td><input type="text" name="stair" id="stair" value="{{ old('stair') }}" /></td>
-            </tr>
-            <tr>
-                <td><label for="comment">コメント</label></td>
-                <td><textarea name="comment" id="comment">{{ old('comment') }}</textarea></td>
-            </tr>
-        </table>
-        <button type="submit">登録</button>
-    </form>
-@endsection
-
-
-{{--        @section('content')--}}
-{{--            @if ($errors->any())--}}
-{{--                <ul>--}}
-{{--                    @foreach ($errors->all() as $error)--}}
-{{--                        <li>{{ $error }}</li>--}}
-{{--                    @endforeach--}}
-{{--                </ul>--}}
-{{--            @endif--}}
-{{--            <form action="{{ route('offices.store') }}" method="post">--}}
-{{--                @csrf--}}
-{{--                <table>--}}
-{{--                    <tr>--}}
-{{--                        <td><label for="name">施設名</label></td>--}}
-{{--                        <td><input type="text" name="name" id="name" value="{{ old('name') }}"/></td>--}}
-{{--                    </tr>--}}
-{{--                    <tr>--}}
-{{--                        <td><label for="address">住所</label></td>--}}
-{{--                        <td><input type="text" name="address" id="address" value="{{ old('address') }}" /></td>--}}
-{{--                    </tr>--}}
-{{--                    <tr>--}}
-{{--                        <td><label for="post_code">郵便番号</label></td>--}}
-{{--                        <td><input type="text" name="post_code" id="post_code" value="{{ old('post_code') }}" /></td>--}}
-{{--                    </tr>--}}
-{{--                    <tr>--}}
-{{--                        <td><label for="stair">階</label></td>--}}
-{{--                        <td><input type="text" name="stair" id="stair" value="{{ old('stair') }}" /></td>--}}
-{{--                    </tr>--}}
-{{--                    <tr>--}}
-{{--                        <td><label for="comment">コメント</label></td>--}}
-{{--                        <td><textarea name="comment" id="comment">{{ old('comment') }}</textarea></td>--}}
-{{--                    </tr>--}}
-{{--                </table>--}}
-{{--                <button type="submit">登録</button>--}}
+    <h1>オフィス新規登録</h1>
+    @include('offices.components.form', ['office' => null,
+                                         'action' => route('offices.store'),
+                                         'isUpdate' => false
+                                        ])
+{{--    ajaxで使う --}}
+{{--    <ul data-error-message></ul>--}}
+{{--    <form data-office-create>--}}
+{{--        @csrf--}}
+{{--        <table>--}}
+{{--            <tr>--}}
+{{--                <td><label for="name">施設名</label></td>--}}
+{{--                <td><input type="text" name="name" id="name" value="{{ old('name') }}"/></td>--}}
+{{--            </tr>--}}
+{{--            <tr>--}}
+{{--                <td><label for="address">住所</label></td>--}}
+{{--                <td><input type="text" name="address" id="address" value="{{ old('address') }}" /></td>--}}
+{{--            </tr>--}}
+{{--            <tr>--}}
+{{--                <td><label for="post_code">郵便番号</label></td>--}}
+{{--                <td><input type="text" name="post_code" id="post_code" value="{{ old('post_code') }}" /></td>--}}
+{{--            </tr>--}}
+{{--            <tr>--}}
+{{--                <td><label for="stair">階</label></td>--}}
+{{--                <td><input type="text" name="stair" id="stair" value="{{ old('stair') }}" /></td>--}}
+{{--            </tr>--}}
+{{--            <tr>--}}
+{{--                <td><label for="comment">コメント</label></td>--}}
+{{--                <td><textarea name="comment" id="comment">{{ old('comment') }}</textarea></td>--}}
+{{--            </tr>--}}
+{{--        </table>--}}
+{{--        <button type="submit">登録</button>--}}
+{{--    </form>--}}
 {{--@endsection--}}
+@endsection

--- a/resources/views/offices/edit.blade.php
+++ b/resources/views/offices/edit.blade.php
@@ -1,0 +1,10 @@
+@extends('layouts.app')
+@section('title', 'edit office')
+@section('content')
+    <h1>ビル編集</h1>
+    @include('offices.components.form', [
+                                            'office' => $office,
+                                            'action' => route('offices.update', $office),
+                                            'isUpdate' => true
+                                        ])
+@endsection

--- a/resources/views/offices/show.blade.php
+++ b/resources/views/offices/show.blade.php
@@ -25,5 +25,6 @@
         </tr>
     </table>
     <br />
+    <a href="{{ route('offices.edit', $office) }}">編集</a>
     <a href="{{ route('offices.index') }}">オフィス一覧</a>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,9 @@ Route::get('/hello', 'App\Http\Controllers\HelloController@index');
 
 Route::prefix('offices')->name('offices.')->group(function () {
     Route::get('/', 'App\Http\Controllers\OfficesController@index')->name('index');
-    Route::get('/create', 'App\Http\Controllers\OfficesController@create')->name('create');
-    Route::get('/{id}', 'App\Http\Controllers\OfficesController@show')->name('show');
     Route::post('/', 'App\Http\Controllers\OfficesController@store')->name('store');
+    Route::get('/create', 'App\Http\Controllers\OfficesController@create')->name('create');
+    Route::get('/{id}/edit', 'App\Http\Controllers\OfficesController@edit')->name('edit');
+    Route::get('/{id}', 'App\Http\Controllers\OfficesController@show')->name('show');
+    Route::put('/{id}', 'App\Http\Controllers\OfficesController@update')->name('update');
 });


### PR DESCRIPTION
## 対応したISSUE・対応したスプレッドシートのリンク

- #9

## 対応した分野

- ロジック処理

## 実装内容

オフィスの更新処理を実装

## テスト方法

`/offices/edit/{id}`にアクセスし、以下の項目を確認する
- 正常パターン
  - フォームの初期値がDBの値と一致していること
  - フォームに値を入力し、更新ボタンを押すとDBの値が更新されること
  - 更新後、一覧画面にリダイレクトされること
  - 更新後、一覧画面に更新したオフィスが表示されること
  - 住所の重複チェックで自身の住所は重複してもエラーにならないこと

- エラーパターン
  - オフィスの登録処理が壊れていない

## APIサーバーへの変更

- [x] 本番反映済み（APIの修正がない場合もチェック）

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
