### PR TITLE
#11 オフィスの論理削除の実装

### DIFF
--- a/app/Http/Controllers/OfficesController.php
+++ b/app/Http/Controllers/OfficesController.php
@@ -99,4 +99,16 @@ class OfficesController extends Controller
         return redirect()->route('offices.index');
     }
 
+    /**
+     * 物件削除処理
+     * @param int $id
+     * @return RedirectResponse
+     */
+    public function destroy(int $id): RedirectResponse
+    {
+        Office::findorFail($id)->delete();
+
+        return redirect()->route('offices.index');
+    }
+
 }

--- a/app/Models/Office.php
+++ b/app/Models/Office.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\CustomSoftDelete;
 use Eloquent;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -17,6 +18,7 @@ use Illuminate\Support\Facades\DB;
 class Office extends Model
 {
     use HasFactory;
+    use CustomSoftDelete;
 
     protected $fillable = [
         'name',
@@ -33,7 +35,7 @@ class Office extends Model
      */
     public function registerOffice(array $inputData): void
     {
-        (new self)->fill($inputData)->save();
+        $this->fill($inputData)->save();
     }
 
     /**

--- a/app/Traits/CustomSoftDelete.php
+++ b/app/Traits/CustomSoftDelete.php
@@ -1,0 +1,51 @@
+<?php
+
+    namespace App\Traits;
+
+
+    trait CustomSoftDelete
+    {
+
+        /**
+         * 起動時の処理
+         * @return void
+         */
+        public static function bootCustomSoftDelete(): void
+        {
+            static::addGlobalScope('CustomSoftDelete', function ($builder) {
+                $builder->where('del_flg', 0);
+            });
+        }
+
+        /**
+         * モデルの論理削除
+         * @return bool
+         */
+        public function delete(): bool
+        {
+            // 削除フラグをセット
+            $this->setAttribute('del_flg', 1);
+            return $this->save();
+        }
+
+        /**
+         * モデルの復元
+         * @return bool
+         */
+        public function restore(): bool
+        {
+            // 削除フラグをリセット
+            $this->setAttribute('del_flg', 0);
+            return $this->save();
+        }
+
+        /**
+         * モデルの永続削除
+         * @return bool|null
+         */
+        public function forceDelete(): ?bool
+        {
+            // 標準の削除処理を実行
+            return parent::delete();
+        }
+    }

--- a/database/migrations/2024_11_01_070035_add_delflg_to_offices_table.php
+++ b/database/migrations/2024_11_01_070035_add_delflg_to_offices_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDelflgToOfficesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('offices', function (Blueprint $table) {
+            $table->integer('del_flg')->default(0)->after('comment');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('offices', function (Blueprint $table) {
+            $table->dropColumn('del_flg');
+        });
+    }
+}

--- a/resources/views/offices/show.blade.php
+++ b/resources/views/offices/show.blade.php
@@ -25,6 +25,11 @@
         </tr>
     </table>
     <br />
+    <form action="{{ route('offices.destroy', $office) }}" method="post">
+        @csrf
+        @method('DELETE')
+        <input type="submit" value="削除">
+    </form>
     <a href="{{ route('offices.edit', $office) }}">編集</a>
     <a href="{{ route('offices.index') }}">オフィス一覧</a>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,4 +26,5 @@ Route::prefix('offices')->name('offices.')->group(function () {
     Route::get('/{id}/edit', 'App\Http\Controllers\OfficesController@edit')->name('edit');
     Route::get('/{id}', 'App\Http\Controllers\OfficesController@show')->name('show');
     Route::put('/{id}', 'App\Http\Controllers\OfficesController@update')->name('update');
+    Route::delete('/{id}', 'App\Http\Controllers\OfficesController@destroy')->name('destroy');
 });


### PR DESCRIPTION
## 対応したISSUE・対応したスプレッドシートのリンク

- #11

## 対応した分野

- ロジック処理

## 実装内容

traitによって、複数のクラスで論理削除ができるようにした
また、作成したtraitでは、CRUD時にglobalscopeを利用して、論理削除されていないデータのみを取得するようにした

## テスト方法

- 正常パターン

- エラーパターン

## APIサーバーへの変更

- [x] 本番反映済み（APIの修正がない場合もチェック）

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
